### PR TITLE
Removed unused ExceptionReporter.format_exception() method.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -440,18 +440,6 @@ class ExceptionReporter:
 
         return frames
 
-    def format_exception(self):
-        """
-        Return the same data as from traceback.format_exception.
-        """
-        import traceback
-        frames = self.get_traceback_frames()
-        tb = [(f['filename'], f['lineno'], f['function'], f['context_line']) for f in frames]
-        list = ['Traceback (most recent call last):\n']
-        list += traceback.format_list(tb)
-        list += traceback.format_exception_only(self.exc_type, self.exc_value)
-        return list
-
 
 def technical_404_response(request, exception):
     "Create a technical 404 error response. The exception should be the Http404."


### PR DESCRIPTION
Unused since its introduction in e7e4b8b0f774b119bc1c46a62a97e51d7c8a35e3.